### PR TITLE
Add radius slider for pie menu

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Windows;
@@ -15,6 +16,10 @@ namespace PieOverlay
         // Keeps the 8 labels; defaulted here but will be overridden in Settings
         public string[] ItemNames { get; } =
             { "Item1","Item2","Item3","Item4","Item5","Item6","Item7","Item8" };
+
+        // Hotkeys for each item; editable via settings
+        public string[] ItemHotkeys { get; } =
+            { "Ctrl+A","Ctrl+N","Delete","Esc","","","","" };
 
         // Radius of the pie menu; default 100 but configurable in settings
         public double Radius { get; set; } = 100;
@@ -98,12 +103,8 @@ namespace PieOverlay
                         if (hit?.VisualHit is Border b)
                         {
                             int idx = wnd.MainCanvas.Children.IndexOf(b);
-                            switch (idx)
-                            {
-                                case 0: SendCtrlKey(0x41); break; // Ctrl+A
-                                case 1: SendCtrlKey(0x4E); break; // Ctrl+N
-                                // …etc for items 3–8
-                            }
+                            if (idx >= 0 && idx < wnd.ItemHotkeys.Length)
+                                SendHotkey(wnd.ItemHotkeys[idx]);
                         }
 
                         wnd.MainCanvas.Children.Clear();
@@ -120,14 +121,61 @@ namespace PieOverlay
             return CallNextHookEx(_hookID, nCode, wParam, lParam);
         }
 
-        private static void SendCtrlKey(byte key)
+        private static void SendHotkey(string hotkey)
         {
-            const byte VK_CONTROL      = 0x11;
+            if (string.IsNullOrWhiteSpace(hotkey))
+                return;
+
+            const byte VK_CONTROL = 0x11;
+            const byte VK_SHIFT   = 0x10;
+            const byte VK_MENU    = 0x12; // Alt
             const uint KEYDOWN = 0x0000, KEYUP = 0x0002;
-            keybd_event(VK_CONTROL, 0, KEYDOWN, UIntPtr.Zero);
-            keybd_event(key,         0, KEYDOWN, UIntPtr.Zero);
-            keybd_event(key,         0, KEYUP,   UIntPtr.Zero);
-            keybd_event(VK_CONTROL, 0, KEYUP,   UIntPtr.Zero);
+
+            var parts = hotkey.Split('+');
+            var modifiers = new List<byte>();
+            byte mainKey = 0;
+
+            foreach (var part in parts)
+            {
+                switch (part.Trim().ToUpper())
+                {
+                    case "CTRL":
+                    case "CONTROL":
+                        modifiers.Add(VK_CONTROL);
+                        break;
+                    case "ALT":
+                        modifiers.Add(VK_MENU);
+                        break;
+                    case "SHIFT":
+                        modifiers.Add(VK_SHIFT);
+                        break;
+                    case "DELETE":
+                        mainKey = 0x2E;
+                        break;
+                    case "ESC":
+                    case "ESCAPE":
+                        mainKey = 0x1B;
+                        break;
+                    default:
+                        if (part.Length == 1)
+                            mainKey = (byte)char.ToUpper(part[0]);
+                        else if (part.StartsWith("F") && int.TryParse(part[1..], out int f) && f >= 1 && f <= 24)
+                            mainKey = (byte)(0x70 + f - 1);
+                        break;
+                }
+            }
+
+            foreach (var m in modifiers)
+                keybd_event(m, 0, KEYDOWN, UIntPtr.Zero);
+
+            if (mainKey != 0)
+            {
+                keybd_event(mainKey, 0, KEYDOWN, UIntPtr.Zero);
+                keybd_event(mainKey, 0, KEYUP,   UIntPtr.Zero);
+            }
+
+            for (int i = modifiers.Count - 1; i >= 0; i--)
+                keybd_event(modifiers[i], 0, KEYUP, UIntPtr.Zero);
         }
 
         protected override void OnClosed(EventArgs e)

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -143,51 +143,32 @@ namespace PieOverlay
             const byte VK_MENU    = 0x12; // Alt
             const uint KEYDOWN = 0x0000, KEYUP = 0x0002;
 
-            var parts = hotkey.Split('+');
-            var modifiers = new List<byte>();
-            byte mainKey = 0;
-
-            foreach (var part in parts)
+            try
             {
-                switch (part.Trim().ToUpper())
-                {
-                    case "CTRL":
-                    case "CONTROL":
-                        modifiers.Add(VK_CONTROL);
-                        break;
-                    case "ALT":
-                        modifiers.Add(VK_MENU);
-                        break;
-                    case "SHIFT":
-                        modifiers.Add(VK_SHIFT);
-                        break;
-                    case "DELETE":
-                        mainKey = 0x2E;
-                        break;
-                    case "ESC":
-                    case "ESCAPE":
-                        mainKey = 0x1B;
-                        break;
-                    default:
-                        if (part.Length == 1)
-                            mainKey = (byte)char.ToUpper(part[0]);
-                        else if (part.StartsWith("F") && int.TryParse(part[1..], out int f) && f >= 1 && f <= 24)
-                            mainKey = (byte)(0x70 + f - 1);
-                        break;
-                }
-            }
+                var converter = new KeyGestureConverter();
+                if (converter.ConvertFromString(hotkey) is not KeyGesture gesture)
+                    return;
 
-            foreach (var m in modifiers)
-                keybd_event(m, 0, KEYDOWN, UIntPtr.Zero);
+                var modifiers = new List<byte>();
+                if (gesture.Modifiers.HasFlag(ModifierKeys.Control)) modifiers.Add(VK_CONTROL);
+                if (gesture.Modifiers.HasFlag(ModifierKeys.Shift))   modifiers.Add(VK_SHIFT);
+                if (gesture.Modifiers.HasFlag(ModifierKeys.Alt))     modifiers.Add(VK_MENU);
 
-            if (mainKey != 0)
-            {
+                byte mainKey = (byte)KeyInterop.VirtualKeyFromKey(gesture.Key);
+
+                foreach (var m in modifiers)
+                    keybd_event(m, 0, KEYDOWN, UIntPtr.Zero);
+
                 keybd_event(mainKey, 0, KEYDOWN, UIntPtr.Zero);
                 keybd_event(mainKey, 0, KEYUP,   UIntPtr.Zero);
-            }
 
-            for (int i = modifiers.Count - 1; i >= 0; i--)
-                keybd_event(modifiers[i], 0, KEYUP, UIntPtr.Zero);
+                for (int i = modifiers.Count - 1; i >= 0; i--)
+                    keybd_event(modifiers[i], 0, KEYUP, UIntPtr.Zero);
+            }
+            catch (FormatException)
+            {
+                // ignore invalid hotkey strings
+            }
         }
 
         protected override void OnClosed(EventArgs e)

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -13,8 +13,11 @@ namespace PieOverlay
     public partial class MainWindow : Window
     {
         // Keeps the 8 labels; defaulted here but will be overridden in Settings
-        public string[] ItemNames { get; } = 
+        public string[] ItemNames { get; } =
             { "Item1","Item2","Item3","Item4","Item5","Item6","Item7","Item8" };
+
+        // Radius of the pie menu; default 100 but configurable in settings
+        public double Radius { get; set; } = 100;
 
         // Low-level hook constants
         private const int WH_KEYBOARD_LL   = 13;
@@ -142,7 +145,7 @@ namespace PieOverlay
                 pt = ct.TransformFromDevice.Transform(pt);
 
             const int count = 8;
-            double radius = 100, w = 80, h = 30;
+            double radius = Radius, w = 80, h = 30;
             double cw = radius * 2 + w, ch = radius * 2 + h;
             Width  = cw;  Height = ch;
             MainCanvas.Width  = cw;

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -99,25 +99,25 @@ namespace PieOverlay
                     // "1" up selects hovered slice & hides
                     else if (vkCode == VK_1 && up && wnd._visible)
                     {
-                        // hit‐test; VisualHit might be the TextBlock inside the Border,
-                        // so walk up the tree until we find the enclosing Border element
                         Point rel = Mouse.GetPosition(wnd.MainCanvas);
-                        var hit   = VisualTreeHelper.HitTest(wnd.MainCanvas, rel);
-
-                        Border? border = null;
-                        DependencyObject? cur = hit?.VisualHit;
-                        while (cur != null && border == null)
-                        {
-                            if (cur is Border b)
-                                border = b;
-                            else
-                                cur = VisualTreeHelper.GetParent(cur);
-                        }
 
                         string? toSend = null;
-                        if (border != null)
+
+                        double cw = wnd.MainCanvas.Width;
+                        double ch = wnd.MainCanvas.Height;
+                        double dx = rel.X - cw / 2;
+                        double dy = rel.Y - ch / 2;
+                        double dist = Math.Sqrt(dx * dx + dy * dy);
+
+                        if (dist >= wnd.Radius / 2)
                         {
-                            int idx = wnd.MainCanvas.Children.IndexOf(border);
+                            double angle = Math.Atan2(dy, dx);
+                            double degrees = angle * 180 / Math.PI;
+                            if (degrees < 0) degrees += 360;
+
+                            int count = wnd.ItemHotkeys.Length;
+                            double seg = 360.0 / count;
+                            int idx = (int)Math.Floor((degrees + seg / 2) / seg) % count;
                             if (idx >= 0 && idx < wnd.ItemHotkeys.Length)
                                 toSend = wnd.ItemHotkeys[idx];
                         }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -63,8 +63,11 @@ namespace PieOverlay
         // Open the settings dialog
         public void OpenSettings()
         {
-            var dlg = new SettingsWindow(this);
-            dlg.Owner = this;
+            var dlg = new SettingsWindow(this)
+            {
+                Owner = null,
+                WindowStartupLocation = WindowStartupLocation.CenterScreen
+            };
             dlg.ShowDialog();
         }
 

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -37,6 +37,8 @@ namespace PieOverlay
         private static LowLevelKeyboardProc _proc = HookCallback;
         private bool _visible;
         private IntPtr _prevWindow;
+        private double _centerX;
+        private double _centerY;
 
         public MainWindow()
         {
@@ -99,14 +101,12 @@ namespace PieOverlay
                     // "1" up selects hovered slice & hides
                     else if (vkCode == VK_1 && up && wnd._visible)
                     {
-                        Point rel = Mouse.GetPosition(wnd.MainCanvas);
+                        GetCursorPos(out POINT cp);
 
                         string? toSend = null;
 
-                        double cw = wnd.MainCanvas.Width;
-                        double ch = wnd.MainCanvas.Height;
-                        double dx = rel.X - cw / 2;
-                        double dy = rel.Y - ch / 2;
+                        double dx = cp.X - wnd._centerX;
+                        double dy = cp.Y - wnd._centerY;
 
                         if (dx != 0 || dy != 0)
                         {
@@ -189,6 +189,9 @@ namespace PieOverlay
         private void DrawEightRects()
         {
             GetCursorPos(out POINT p);
+            _centerX = p.X;
+            _centerY = p.Y;
+
             var pt = new Point(p.X, p.Y);
             if (PresentationSource.FromVisual(this) is { CompositionTarget: var ct })
                 pt = ct.TransformFromDevice.Transform(pt);

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -97,12 +97,24 @@ namespace PieOverlay
                     // "1" up selects hovered slice & hides
                     else if (vkCode == VK_1 && up && wnd._visible)
                     {
-                        // hit‐test
+                        // hit‐test; VisualHit might be the TextBlock inside the Border,
+                        // so walk up the tree until we find the enclosing Border element
                         Point rel = Mouse.GetPosition(wnd.MainCanvas);
-                        var hit = VisualTreeHelper.HitTest(wnd.MainCanvas, rel);
-                        if (hit?.VisualHit is Border b)
+                        var hit   = VisualTreeHelper.HitTest(wnd.MainCanvas, rel);
+
+                        Border? border = null;
+                        DependencyObject? cur = hit?.VisualHit;
+                        while (cur != null && border == null)
                         {
-                            int idx = wnd.MainCanvas.Children.IndexOf(b);
+                            if (cur is Border b)
+                                border = b;
+                            else
+                                cur = VisualTreeHelper.GetParent(cur);
+                        }
+
+                        if (border != null)
+                        {
+                            int idx = wnd.MainCanvas.Children.IndexOf(border);
                             if (idx >= 0 && idx < wnd.ItemHotkeys.Length)
                                 SendHotkey(wnd.ItemHotkeys[idx]);
                         }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -11,6 +11,8 @@ using System.Windows.Threading;
 
 namespace PieOverlay
 {
+    public enum SelectionMode { Hover, Click }
+
     public partial class MainWindow : Window
     {
         // Keeps the 8 labels; defaulted here but will be overridden in Settings
@@ -23,6 +25,9 @@ namespace PieOverlay
 
         // Radius of the pie menu; default 100 but configurable in settings
         public double Radius { get; set; } = 100;
+
+        // Selection behavior: hover (default) or click
+        public SelectionMode Behavior { get; set; } = SelectionMode.Hover;
 
         // Low-level hook constants
         private const int WH_KEYBOARD_LL   = 13;
@@ -90,24 +95,43 @@ namespace PieOverlay
                     {
                         wnd.OpenSettings();
                     }
-                    // "1" down shows pie
-                    else if (vkCode == VK_1 && down && !wnd._visible)
+                    // "1" down handles showing/hiding
+                    else if (vkCode == VK_1 && down)
                     {
-                        wnd._prevWindow = GetForegroundWindow();
-                        wnd.DrawEightRects();
-                        wnd.Visibility = Visibility.Visible;
-                        wnd._visible   = true;
+                        if (wnd.Behavior == SelectionMode.Hover)
+                        {
+                            if (!wnd._visible)
+                            {
+                                wnd._prevWindow = GetForegroundWindow();
+                                wnd.DrawEightRects();
+                                wnd.Visibility = Visibility.Visible;
+                                wnd._visible   = true;
+                            }
+                        }
+                        else // click behavior toggles
+                        {
+                            if (!wnd._visible)
+                            {
+                                wnd._prevWindow = GetForegroundWindow();
+                                wnd.DrawEightRects();
+                                wnd.Visibility = Visibility.Visible;
+                                wnd._visible   = true;
+                            }
+                            else
+                            {
+                                wnd.HideOverlay();
+                            }
+                        }
                     }
-                    // "1" up selects hovered slice & hides
-                    else if (vkCode == VK_1 && up && wnd._visible)
+                    // "1" up selects hovered slice in hover mode
+                    else if (vkCode == VK_1 && up && wnd._visible && wnd.Behavior == SelectionMode.Hover)
                     {
                         GetCursorPos(out POINT cp);
-
-                        string? toSend = null;
 
                         double dx = cp.X - wnd._centerX;
                         double dy = cp.Y - wnd._centerY;
 
+                        int idx = -1;
                         if (dx != 0 || dy != 0)
                         {
                             double angle = Math.Atan2(dy, dx);
@@ -116,20 +140,10 @@ namespace PieOverlay
 
                             int count = wnd.ItemHotkeys.Length;
                             double seg = 360.0 / count;
-                            int idx = (int)Math.Floor((degrees + seg / 2) / seg) % count;
-                            if (idx >= 0 && idx < wnd.ItemHotkeys.Length)
-                                toSend = wnd.ItemHotkeys[idx];
+                            idx = (int)Math.Floor((degrees + seg / 2) / seg) % count;
                         }
 
-                        wnd.MainCanvas.Children.Clear();
-                        wnd.Visibility = Visibility.Hidden;
-                        wnd._visible   = false;
-
-                        if (wnd._prevWindow != IntPtr.Zero)
-                            SetForegroundWindow(wnd._prevWindow);
-
-                        if (!string.IsNullOrWhiteSpace(toSend))
-                            wnd.Dispatcher.BeginInvoke(new Action(() => SendHotkey(toSend)), DispatcherPriority.Background);
+                        wnd.ActivateIndex(idx);
                     }
                 }, DispatcherPriority.Send);
 
@@ -177,6 +191,37 @@ namespace PieOverlay
             {
                 // ignore invalid hotkey strings
             }
+        }
+
+        private void ActivateIndex(int idx)
+        {
+            HideOverlay();
+
+            if (idx >= 0 && idx < ItemHotkeys.Length)
+            {
+                string toSend = ItemHotkeys[idx];
+                if (!string.IsNullOrWhiteSpace(toSend))
+                    Dispatcher.BeginInvoke(new Action(() => SendHotkey(toSend)), DispatcherPriority.Background);
+            }
+        }
+
+        private void HideOverlay()
+        {
+            MainCanvas.Children.Clear();
+            Visibility = Visibility.Hidden;
+            _visible   = false;
+
+            if (_prevWindow != IntPtr.Zero)
+                SetForegroundWindow(_prevWindow);
+        }
+
+        private void OnItemClick(object sender, MouseButtonEventArgs e)
+        {
+            if (Behavior != SelectionMode.Click)
+                return;
+
+            if (sender is Border b && b.Tag is int idx)
+                ActivateIndex(idx);
         }
 
         protected override void OnClosed(EventArgs e)
@@ -236,6 +281,9 @@ namespace PieOverlay
                 border.Child = label;
                 Canvas.SetLeft(border, x);
                 Canvas.SetTop(border, y);
+                border.Tag = i;
+                if (Behavior == SelectionMode.Click)
+                    border.MouseLeftButtonDown += OnItemClick;
                 MainCanvas.Children.Add(border);
             }
         }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -107,9 +107,8 @@ namespace PieOverlay
                         double ch = wnd.MainCanvas.Height;
                         double dx = rel.X - cw / 2;
                         double dy = rel.Y - ch / 2;
-                        double dist = Math.Sqrt(dx * dx + dy * dy);
 
-                        if (dist >= wnd.Radius / 2)
+                        if (dx != 0 || dy != 0)
                         {
                             double angle = Math.Atan2(dy, dx);
                             double degrees = angle * 180 / Math.PI;

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -36,6 +36,7 @@ namespace PieOverlay
         private static IntPtr _hookID = IntPtr.Zero;
         private static LowLevelKeyboardProc _proc = HookCallback;
         private bool _visible;
+        private IntPtr _prevWindow;
 
         public MainWindow()
         {
@@ -90,6 +91,7 @@ namespace PieOverlay
                     // "1" down shows pie
                     else if (vkCode == VK_1 && down && !wnd._visible)
                     {
+                        wnd._prevWindow = GetForegroundWindow();
                         wnd.DrawEightRects();
                         wnd.Visibility = Visibility.Visible;
                         wnd._visible   = true;
@@ -112,16 +114,23 @@ namespace PieOverlay
                                 cur = VisualTreeHelper.GetParent(cur);
                         }
 
+                        string? toSend = null;
                         if (border != null)
                         {
                             int idx = wnd.MainCanvas.Children.IndexOf(border);
                             if (idx >= 0 && idx < wnd.ItemHotkeys.Length)
-                                SendHotkey(wnd.ItemHotkeys[idx]);
+                                toSend = wnd.ItemHotkeys[idx];
                         }
 
                         wnd.MainCanvas.Children.Clear();
                         wnd.Visibility = Visibility.Hidden;
                         wnd._visible   = false;
+
+                        if (wnd._prevWindow != IntPtr.Zero)
+                            SetForegroundWindow(wnd._prevWindow);
+
+                        if (!string.IsNullOrWhiteSpace(toSend))
+                            wnd.Dispatcher.BeginInvoke(new Action(() => SendHotkey(toSend)), DispatcherPriority.Background);
                     }
                 }, DispatcherPriority.Send);
 
@@ -233,6 +242,8 @@ namespace PieOverlay
         #region Win32 + Hook P/Invoke
         [DllImport("user32.dll")] private static extern bool GetCursorPos(out POINT lpPoint);
         [StructLayout(LayoutKind.Sequential)] private struct POINT { public int X, Y; }
+        [DllImport("user32.dll")] private static extern IntPtr GetForegroundWindow();
+        [DllImport("user32.dll")] private static extern bool SetForegroundWindow(IntPtr hWnd);
         [DllImport("user32.dll", SetLastError=true)]
         private static extern IntPtr SetWindowsHookEx(int idHook, LowLevelKeyboardProc lpfn, IntPtr hMod, uint dwThreadId);
         [DllImport("user32.dll", SetLastError=true)]

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -15,16 +15,18 @@ namespace PieOverlay
 
     public partial class MainWindow : Window
     {
-        // Keeps the 8 labels; defaulted here but will be overridden in Settings
-        public string[] ItemNames { get; } =
-            { "Item1","Item2","Item3","Item4","Item5","Item6","Item7","Item8" };
+        // Item labels and hotkeys; defaulted but resized via settings
+        public List<string> ItemNames   { get; } = new();
+        public List<string> ItemHotkeys { get; } = new();
 
-        // Hotkeys for each item; editable via settings
-        public string[] ItemHotkeys { get; } =
-            { "Ctrl+A","Ctrl+N","Delete","Esc","","","","" };
+        // Radius of the pie menu and optional dead zone
+        public double Radius        { get; set; } = 100;
+        public double DeadZoneRadius{ get; set; } = 0;
 
-        // Radius of the pie menu; default 100 but configurable in settings
-        public double Radius { get; set; } = 100;
+        // Visual settings for items
+        public Brush     ItemColor      { get; set; } = Brushes.LightBlue;
+        public double    ItemFontSize   { get; set; } = 14;
+        public FontFamily ItemFontFamily { get; set; } = new("Segoe UI");
 
         // Selection behavior: hover (default) or click
         public SelectionMode Behavior { get; set; } = SelectionMode.Hover;
@@ -54,6 +56,8 @@ namespace PieOverlay
 
             Topmost    = true;
             Visibility = Visibility.Hidden;
+
+            EnsureItemCount(8);
         }
 
         // Open the settings dialog
@@ -138,10 +142,14 @@ namespace PieOverlay
                             double degrees = angle * 180 / Math.PI;
                             if (degrees < 0) degrees += 360;
 
-                            int count = wnd.ItemHotkeys.Length;
+                            int count = wnd.ItemHotkeys.Count;
                             double seg = 360.0 / count;
                             idx = (int)Math.Floor((degrees + seg / 2) / seg) % count;
                         }
+
+                        double dist = Math.Sqrt(dx*dx + dy*dy);
+                        if (dist < wnd.DeadZoneRadius)
+                            idx = -1;
 
                         wnd.ActivateIndex(idx);
                     }
@@ -197,7 +205,7 @@ namespace PieOverlay
         {
             HideOverlay();
 
-            if (idx >= 0 && idx < ItemHotkeys.Length)
+            if (idx >= 0 && idx < ItemHotkeys.Count)
             {
                 string toSend = ItemHotkeys[idx];
                 if (!string.IsNullOrWhiteSpace(toSend))
@@ -213,6 +221,25 @@ namespace PieOverlay
 
             if (_prevWindow != IntPtr.Zero)
                 SetForegroundWindow(_prevWindow);
+        }
+
+        public void EnsureItemCount(int count)
+        {
+            if (count < 1) count = 1;
+            if (count > 50) count = 50;
+
+            while (ItemNames.Count < count)
+            {
+                int i = ItemNames.Count + 1;
+                ItemNames.Add($"Item{i}");
+                ItemHotkeys.Add(string.Empty);
+            }
+
+            while (ItemNames.Count > count)
+            {
+                ItemNames.RemoveAt(ItemNames.Count - 1);
+                ItemHotkeys.RemoveAt(ItemHotkeys.Count - 1);
+            }
         }
 
         private void OnItemClick(object sender, MouseButtonEventArgs e)
@@ -241,7 +268,7 @@ namespace PieOverlay
             if (PresentationSource.FromVisual(this) is { CompositionTarget: var ct })
                 pt = ct.TransformFromDevice.Transform(pt);
 
-            const int count = 8;
+            int count = ItemNames.Count;
             double radius = Radius, w = 80, h = 30;
             double cw = radius * 2 + w, ch = radius * 2 + h;
             Width  = cw;  Height = ch;
@@ -266,16 +293,17 @@ namespace PieOverlay
                     Width        = w,
                     Height       = h,
                     CornerRadius = new CornerRadius(6),
-                    Background   = Brushes.LightBlue,
+                    Background   = ItemColor,
                     Effect       = shadow
                 };
 
                 var label = new TextBlock {
                     Text                = ItemNames[i],
-                    FontSize            = 14,
+                    FontSize            = ItemFontSize,
+                    FontFamily          = ItemFontFamily,
                     HorizontalAlignment = HorizontalAlignment.Center,
                     VerticalAlignment   = VerticalAlignment.Center,
-                    Foreground          = Brushes.DarkBlue
+                    Foreground          = Brushes.Black
                 };
 
                 border.Child = label;

--- a/SettingsWindow.xaml
+++ b/SettingsWindow.xaml
@@ -17,6 +17,7 @@
       <RowDefinition Height="Auto"/>
       <RowDefinition Height="Auto"/>
       <RowDefinition Height="Auto"/>
+      <RowDefinition Height="Auto"/>
     </Grid.RowDefinitions>
     <Grid.ColumnDefinitions>
       <ColumnDefinition Width="Auto"/>
@@ -48,8 +49,11 @@
     <Label Content="Item 8:" Grid.Row="7" Grid.Column="0" VerticalAlignment="Center"/>
     <TextBox x:Name="Txt7" Grid.Row="7" Grid.Column="1" Margin="4"/>
 
+    <Label Content="Radius:" Grid.Row="8" Grid.Column="0" VerticalAlignment="Center"/>
+    <Slider x:Name="SldRadius" Grid.Row="8" Grid.Column="1" Margin="4" Minimum="50" Maximum="200" TickFrequency="10" IsSnapToTickEnabled="True"/>
+
     <!-- buttons -->
-    <StackPanel Grid.Row="8" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+    <StackPanel Grid.Row="9" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
       <Button Content="Save"   Width="75" Margin="4" Click="OnSave"/>
       <Button Content="Cancel" Width="75" Margin="4" Click="OnCancel"/>
     </StackPanel>

--- a/SettingsWindow.xaml
+++ b/SettingsWindow.xaml
@@ -2,76 +2,57 @@
     x:Class="PieOverlay.SettingsWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    Title="Pie Menu Settings"
-    Height="350" Width="400"
-    WindowStartupLocation="CenterOwner"
-    ResizeMode="NoResize">
-  <Grid Margin="10">
-    <Grid.RowDefinitions>
-      <RowDefinition Height="Auto"/>
-      <RowDefinition Height="Auto"/>
-      <RowDefinition Height="Auto"/>
-      <RowDefinition Height="Auto"/>
-      <RowDefinition Height="Auto"/>
-      <RowDefinition Height="Auto"/>
-      <RowDefinition Height="Auto"/>
-      <RowDefinition Height="Auto"/>
-      <RowDefinition Height="Auto"/>
-      <RowDefinition Height="Auto"/>
-      <RowDefinition Height="Auto"/>
-    </Grid.RowDefinitions>
-    <Grid.ColumnDefinitions>
-      <ColumnDefinition Width="Auto"/>
-      <ColumnDefinition Width="*"/>
-      <ColumnDefinition Width="*"/>
-    </Grid.ColumnDefinitions>
+    Title="Pie Menu Settings" Height="450" Width="400"
+    WindowStartupLocation="CenterOwner" ResizeMode="NoResize">
+  <DockPanel Margin="10">
+    <ScrollViewer DockPanel.Dock="Top" VerticalScrollBarVisibility="Auto">
+      <StackPanel x:Name="RootStack">
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+          <Label Content="Items:" Width="60"/>
+          <Slider x:Name="SldCount" Minimum="1" Maximum="50" Width="200" ValueChanged="OnCountChanged"/>
+          <TextBlock x:Name="TxtCount" Margin="5,0,0,0" Width="30"/>
+        </StackPanel>
 
-    <!-- labels & textboxes -->
-    <Label Content="Item 1:" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center"/>
-    <TextBox x:Name="Txt0" Grid.Row="0" Grid.Column="1" Margin="4"/>
-    <TextBox x:Name="Hot0" Grid.Row="0" Grid.Column="2" Margin="4"/>
+        <StackPanel x:Name="ItemsPanel"/>
 
-    <Label Content="Item 2:" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center"/>
-    <TextBox x:Name="Txt1" Grid.Row="1" Grid.Column="1" Margin="4"/>
-    <TextBox x:Name="Hot1" Grid.Row="1" Grid.Column="2" Margin="4"/>
+        <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+          <Label Content="Mode:" Width="60"/>
+          <ComboBox x:Name="CmbMode" Width="150">
+            <ComboBoxItem Content="Hover"/>
+            <ComboBoxItem Content="Click"/>
+          </ComboBox>
+        </StackPanel>
 
-    <Label Content="Item 3:" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center"/>
-    <TextBox x:Name="Txt2" Grid.Row="2" Grid.Column="1" Margin="4"/>
-    <TextBox x:Name="Hot2" Grid.Row="2" Grid.Column="2" Margin="4"/>
+        <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+          <Label Content="Radius:" Width="60"/>
+          <Slider x:Name="SldRadius" Minimum="50" Maximum="200" Width="200" TickFrequency="10" IsSnapToTickEnabled="True"/>
+        </StackPanel>
 
-    <Label Content="Item 4:" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center"/>
-    <TextBox x:Name="Txt3" Grid.Row="3" Grid.Column="1" Margin="4"/>
-    <TextBox x:Name="Hot3" Grid.Row="3" Grid.Column="2" Margin="4"/>
+        <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+          <Label Content="Dead Zone:" Width="60"/>
+          <Slider x:Name="SldDead" Minimum="0" Maximum="100" Width="200" TickFrequency="5" IsSnapToTickEnabled="True"/>
+        </StackPanel>
 
-    <Label Content="Item 5:" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center"/>
-    <TextBox x:Name="Txt4" Grid.Row="4" Grid.Column="1" Margin="4"/>
-    <TextBox x:Name="Hot4" Grid.Row="4" Grid.Column="2" Margin="4"/>
+        <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+          <Label Content="Color:" Width="60"/>
+          <TextBox x:Name="TxtColor" Width="200"/>
+        </StackPanel>
 
-    <Label Content="Item 6:" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center"/>
-    <TextBox x:Name="Txt5" Grid.Row="5" Grid.Column="1" Margin="4"/>
-    <TextBox x:Name="Hot5" Grid.Row="5" Grid.Column="2" Margin="4"/>
+        <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+          <Label Content="Font Size:" Width="60"/>
+          <Slider x:Name="SldFont" Minimum="8" Maximum="40" Width="200" TickFrequency="1" IsSnapToTickEnabled="True"/>
+        </StackPanel>
 
-    <Label Content="Item 7:" Grid.Row="6" Grid.Column="0" VerticalAlignment="Center"/>
-    <TextBox x:Name="Txt6" Grid.Row="6" Grid.Column="1" Margin="4"/>
-    <TextBox x:Name="Hot6" Grid.Row="6" Grid.Column="2" Margin="4"/>
+        <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+          <Label Content="Font:" Width="60"/>
+          <TextBox x:Name="TxtFont" Width="200"/>
+        </StackPanel>
+      </StackPanel>
+    </ScrollViewer>
 
-    <Label Content="Item 8:" Grid.Row="7" Grid.Column="0" VerticalAlignment="Center"/>
-    <TextBox x:Name="Txt7" Grid.Row="7" Grid.Column="1" Margin="4"/>
-    <TextBox x:Name="Hot7" Grid.Row="7" Grid.Column="2" Margin="4"/>
-
-    <Label Content="Mode:" Grid.Row="8" Grid.Column="0" VerticalAlignment="Center"/>
-    <ComboBox x:Name="CmbMode" Grid.Row="8" Grid.Column="1" Grid.ColumnSpan="2" Margin="4">
-      <ComboBoxItem Content="Hover"/>
-      <ComboBoxItem Content="Click"/>
-    </ComboBox>
-
-    <Label Content="Radius:" Grid.Row="9" Grid.Column="0" VerticalAlignment="Center"/>
-    <Slider x:Name="SldRadius" Grid.Row="9" Grid.Column="1" Grid.ColumnSpan="2" Margin="4" Minimum="50" Maximum="200" TickFrequency="10" IsSnapToTickEnabled="True"/>
-
-    <!-- buttons -->
-    <StackPanel Grid.Row="10" Grid.ColumnSpan="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
-      <Button Content="Save"   Width="75" Margin="4" Click="OnSave"/>
+    <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+      <Button Content="Save" Width="75" Margin="4" Click="OnSave"/>
       <Button Content="Cancel" Width="75" Margin="4" Click="OnCancel"/>
     </StackPanel>
-  </Grid>
+  </DockPanel>
 </Window>

--- a/SettingsWindow.xaml
+++ b/SettingsWindow.xaml
@@ -3,7 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     Title="Pie Menu Settings"
-    Height="350" Width="300"
+    Height="350" Width="400"
     WindowStartupLocation="CenterOwner"
     ResizeMode="NoResize">
   <Grid Margin="10">
@@ -22,38 +22,47 @@
     <Grid.ColumnDefinitions>
       <ColumnDefinition Width="Auto"/>
       <ColumnDefinition Width="*"/>
+      <ColumnDefinition Width="*"/>
     </Grid.ColumnDefinitions>
 
     <!-- labels & textboxes -->
     <Label Content="Item 1:" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center"/>
     <TextBox x:Name="Txt0" Grid.Row="0" Grid.Column="1" Margin="4"/>
+    <TextBox x:Name="Hot0" Grid.Row="0" Grid.Column="2" Margin="4"/>
 
     <Label Content="Item 2:" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center"/>
     <TextBox x:Name="Txt1" Grid.Row="1" Grid.Column="1" Margin="4"/>
+    <TextBox x:Name="Hot1" Grid.Row="1" Grid.Column="2" Margin="4"/>
 
     <Label Content="Item 3:" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center"/>
     <TextBox x:Name="Txt2" Grid.Row="2" Grid.Column="1" Margin="4"/>
+    <TextBox x:Name="Hot2" Grid.Row="2" Grid.Column="2" Margin="4"/>
 
     <Label Content="Item 4:" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center"/>
     <TextBox x:Name="Txt3" Grid.Row="3" Grid.Column="1" Margin="4"/>
+    <TextBox x:Name="Hot3" Grid.Row="3" Grid.Column="2" Margin="4"/>
 
     <Label Content="Item 5:" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center"/>
     <TextBox x:Name="Txt4" Grid.Row="4" Grid.Column="1" Margin="4"/>
+    <TextBox x:Name="Hot4" Grid.Row="4" Grid.Column="2" Margin="4"/>
 
     <Label Content="Item 6:" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center"/>
     <TextBox x:Name="Txt5" Grid.Row="5" Grid.Column="1" Margin="4"/>
+    <TextBox x:Name="Hot5" Grid.Row="5" Grid.Column="2" Margin="4"/>
 
     <Label Content="Item 7:" Grid.Row="6" Grid.Column="0" VerticalAlignment="Center"/>
     <TextBox x:Name="Txt6" Grid.Row="6" Grid.Column="1" Margin="4"/>
+    <TextBox x:Name="Hot6" Grid.Row="6" Grid.Column="2" Margin="4"/>
 
     <Label Content="Item 8:" Grid.Row="7" Grid.Column="0" VerticalAlignment="Center"/>
     <TextBox x:Name="Txt7" Grid.Row="7" Grid.Column="1" Margin="4"/>
+    <TextBox x:Name="Hot7" Grid.Row="7" Grid.Column="2" Margin="4"/>
 
     <Label Content="Radius:" Grid.Row="8" Grid.Column="0" VerticalAlignment="Center"/>
-    <Slider x:Name="SldRadius" Grid.Row="8" Grid.Column="1" Margin="4" Minimum="50" Maximum="200" TickFrequency="10" IsSnapToTickEnabled="True"/>
+    <Slider x:Name="SldRadius" Grid.Row="8" Grid.Column="1" Grid.ColumnSpan="2" Margin="4" Minimum="50" Maximum="200" TickFrequency="10" IsSnapToTickEnabled="True"/>
 
     <!-- buttons -->
-    <StackPanel Grid.Row="9" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+    <StackPanel Grid.Row="9" Grid.ColumnSpan="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
       <Button Content="Save"   Width="75" Margin="4" Click="OnSave"/>
       <Button Content="Cancel" Width="75" Margin="4" Click="OnCancel"/>
     </StackPanel>

--- a/SettingsWindow.xaml
+++ b/SettingsWindow.xaml
@@ -3,7 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     Title="Pie Menu Settings" Height="450" Width="400"
-    WindowStartupLocation="CenterOwner" ResizeMode="NoResize">
+    WindowStartupLocation="CenterScreen" ResizeMode="NoResize">
   <DockPanel Margin="10">
     <ScrollViewer DockPanel.Dock="Top" VerticalScrollBarVisibility="Auto">
       <StackPanel x:Name="RootStack">

--- a/SettingsWindow.xaml
+++ b/SettingsWindow.xaml
@@ -18,6 +18,7 @@
       <RowDefinition Height="Auto"/>
       <RowDefinition Height="Auto"/>
       <RowDefinition Height="Auto"/>
+      <RowDefinition Height="Auto"/>
     </Grid.RowDefinitions>
     <Grid.ColumnDefinitions>
       <ColumnDefinition Width="Auto"/>
@@ -58,11 +59,17 @@
     <TextBox x:Name="Txt7" Grid.Row="7" Grid.Column="1" Margin="4"/>
     <TextBox x:Name="Hot7" Grid.Row="7" Grid.Column="2" Margin="4"/>
 
-    <Label Content="Radius:" Grid.Row="8" Grid.Column="0" VerticalAlignment="Center"/>
-    <Slider x:Name="SldRadius" Grid.Row="8" Grid.Column="1" Grid.ColumnSpan="2" Margin="4" Minimum="50" Maximum="200" TickFrequency="10" IsSnapToTickEnabled="True"/>
+    <Label Content="Mode:" Grid.Row="8" Grid.Column="0" VerticalAlignment="Center"/>
+    <ComboBox x:Name="CmbMode" Grid.Row="8" Grid.Column="1" Grid.ColumnSpan="2" Margin="4">
+      <ComboBoxItem Content="Hover"/>
+      <ComboBoxItem Content="Click"/>
+    </ComboBox>
+
+    <Label Content="Radius:" Grid.Row="9" Grid.Column="0" VerticalAlignment="Center"/>
+    <Slider x:Name="SldRadius" Grid.Row="9" Grid.Column="1" Grid.ColumnSpan="2" Margin="4" Minimum="50" Maximum="200" TickFrequency="10" IsSnapToTickEnabled="True"/>
 
     <!-- buttons -->
-    <StackPanel Grid.Row="9" Grid.ColumnSpan="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+    <StackPanel Grid.Row="10" Grid.ColumnSpan="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
       <Button Content="Save"   Width="75" Margin="4" Click="OnSave"/>
       <Button Content="Cancel" Width="75" Margin="4" Click="OnCancel"/>
     </StackPanel>

--- a/SettingsWindow.xaml.cs
+++ b/SettingsWindow.xaml.cs
@@ -21,6 +21,15 @@ namespace PieOverlay
             Txt6.Text = _parent.ItemNames[6];
             Txt7.Text = _parent.ItemNames[7];
 
+            Hot0.Text = _parent.ItemHotkeys[0];
+            Hot1.Text = _parent.ItemHotkeys[1];
+            Hot2.Text = _parent.ItemHotkeys[2];
+            Hot3.Text = _parent.ItemHotkeys[3];
+            Hot4.Text = _parent.ItemHotkeys[4];
+            Hot5.Text = _parent.ItemHotkeys[5];
+            Hot6.Text = _parent.ItemHotkeys[6];
+            Hot7.Text = _parent.ItemHotkeys[7];
+
             // load radius
             SldRadius.Value = _parent.Radius;
         }
@@ -36,6 +45,15 @@ namespace PieOverlay
             _parent.ItemNames[5] = Txt5.Text;
             _parent.ItemNames[6] = Txt6.Text;
             _parent.ItemNames[7] = Txt7.Text;
+
+            _parent.ItemHotkeys[0] = Hot0.Text;
+            _parent.ItemHotkeys[1] = Hot1.Text;
+            _parent.ItemHotkeys[2] = Hot2.Text;
+            _parent.ItemHotkeys[3] = Hot3.Text;
+            _parent.ItemHotkeys[4] = Hot4.Text;
+            _parent.ItemHotkeys[5] = Hot5.Text;
+            _parent.ItemHotkeys[6] = Hot6.Text;
+            _parent.ItemHotkeys[7] = Hot7.Text;
 
             _parent.Radius = SldRadius.Value;
 

--- a/SettingsWindow.xaml.cs
+++ b/SettingsWindow.xaml.cs
@@ -1,63 +1,90 @@
+using System.Collections.Generic;
 using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
 
 namespace PieOverlay
 {
     public partial class SettingsWindow : Window
     {
         private readonly MainWindow _parent;
+        private readonly List<TextBox> _nameBoxes = new();
+        private readonly List<TextBox> _hotBoxes  = new();
 
         public SettingsWindow(MainWindow parent)
         {
             InitializeComponent();
             _parent = parent;
 
-            // load existing values
-            Txt0.Text = _parent.ItemNames[0];
-            Txt1.Text = _parent.ItemNames[1];
-            Txt2.Text = _parent.ItemNames[2];
-            Txt3.Text = _parent.ItemNames[3];
-            Txt4.Text = _parent.ItemNames[4];
-            Txt5.Text = _parent.ItemNames[5];
-            Txt6.Text = _parent.ItemNames[6];
-            Txt7.Text = _parent.ItemNames[7];
-
-            Hot0.Text = _parent.ItemHotkeys[0];
-            Hot1.Text = _parent.ItemHotkeys[1];
-            Hot2.Text = _parent.ItemHotkeys[2];
-            Hot3.Text = _parent.ItemHotkeys[3];
-            Hot4.Text = _parent.ItemHotkeys[4];
-            Hot5.Text = _parent.ItemHotkeys[5];
-            Hot6.Text = _parent.ItemHotkeys[6];
-            Hot7.Text = _parent.ItemHotkeys[7];
-
-            // load radius and behavior
+            SldCount.Value = _parent.ItemNames.Count;
             SldRadius.Value = _parent.Radius;
             CmbMode.SelectedIndex = (int)_parent.Behavior;
+            SldDead.Value = _parent.DeadZoneRadius;
+            SldFont.Value = _parent.ItemFontSize;
+            TxtFont.Text = _parent.ItemFontFamily.Source;
+
+            if (_parent.ItemColor is SolidColorBrush scb)
+                TxtColor.Text = scb.Color.ToString();
+            else
+                TxtColor.Text = "";
+
+            RebuildItemRows((int)SldCount.Value);
+        }
+
+        private void RebuildItemRows(int count)
+        {
+            ItemsPanel.Children.Clear();
+            _nameBoxes.Clear();
+            _hotBoxes.Clear();
+            for (int i = 0; i < count; i++)
+            {
+                var sp = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0,2,0,2) };
+                sp.Children.Add(new Label { Content = $"Item {i+1}:", Width = 60, VerticalAlignment = VerticalAlignment.Center });
+
+                var name = new TextBox { Width = 120, Margin = new Thickness(4,0,4,0) };
+                if (i < _parent.ItemNames.Count) name.Text = _parent.ItemNames[i];
+                sp.Children.Add(name);
+                _nameBoxes.Add(name);
+
+                var hot = new TextBox { Width = 120, Margin = new Thickness(4,0,4,0) };
+                if (i < _parent.ItemHotkeys.Count) hot.Text = _parent.ItemHotkeys[i];
+                sp.Children.Add(hot);
+                _hotBoxes.Add(hot);
+
+                ItemsPanel.Children.Add(sp);
+            }
+            TxtCount.Text = count.ToString();
+        }
+
+        private void OnCountChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            RebuildItemRows((int)SldCount.Value);
         }
 
         private void OnSave(object sender, RoutedEventArgs e)
         {
-            // save back into parent
-            _parent.ItemNames[0] = Txt0.Text;
-            _parent.ItemNames[1] = Txt1.Text;
-            _parent.ItemNames[2] = Txt2.Text;
-            _parent.ItemNames[3] = Txt3.Text;
-            _parent.ItemNames[4] = Txt4.Text;
-            _parent.ItemNames[5] = Txt5.Text;
-            _parent.ItemNames[6] = Txt6.Text;
-            _parent.ItemNames[7] = Txt7.Text;
-
-            _parent.ItemHotkeys[0] = Hot0.Text.Trim();
-            _parent.ItemHotkeys[1] = Hot1.Text.Trim();
-            _parent.ItemHotkeys[2] = Hot2.Text.Trim();
-            _parent.ItemHotkeys[3] = Hot3.Text.Trim();
-            _parent.ItemHotkeys[4] = Hot4.Text.Trim();
-            _parent.ItemHotkeys[5] = Hot5.Text.Trim();
-            _parent.ItemHotkeys[6] = Hot6.Text.Trim();
-            _parent.ItemHotkeys[7] = Hot7.Text.Trim();
+            int count = _nameBoxes.Count;
+            _parent.EnsureItemCount(count);
+            for (int i = 0; i < count; i++)
+            {
+                _parent.ItemNames[i] = _nameBoxes[i].Text;
+                _parent.ItemHotkeys[i] = _hotBoxes[i].Text.Trim();
+            }
 
             _parent.Radius = SldRadius.Value;
             _parent.Behavior = (SelectionMode)CmbMode.SelectedIndex;
+            _parent.DeadZoneRadius = SldDead.Value;
+            _parent.ItemFontSize = SldFont.Value;
+            _parent.ItemFontFamily = new FontFamily(TxtFont.Text);
+            try
+            {
+                var brush = (Brush)new BrushConverter().ConvertFromString(TxtColor.Text);
+                _parent.ItemColor = brush;
+            }
+            catch
+            {
+                // ignore invalid color
+            }
 
             Close();
         }

--- a/SettingsWindow.xaml.cs
+++ b/SettingsWindow.xaml.cs
@@ -78,8 +78,11 @@ namespace PieOverlay
             _parent.ItemFontFamily = new FontFamily(TxtFont.Text);
             try
             {
-                var brush = (Brush)new BrushConverter().ConvertFromString(TxtColor.Text);
-                _parent.ItemColor = brush;
+                var brushObj = new BrushConverter().ConvertFromString(TxtColor.Text);
+                if (brushObj is Brush brush)
+                {
+                    _parent.ItemColor = brush;
+                }
             }
             catch
             {

--- a/SettingsWindow.xaml.cs
+++ b/SettingsWindow.xaml.cs
@@ -20,6 +20,9 @@ namespace PieOverlay
             Txt5.Text = _parent.ItemNames[5];
             Txt6.Text = _parent.ItemNames[6];
             Txt7.Text = _parent.ItemNames[7];
+
+            // load radius
+            SldRadius.Value = _parent.Radius;
         }
 
         private void OnSave(object sender, RoutedEventArgs e)
@@ -33,6 +36,8 @@ namespace PieOverlay
             _parent.ItemNames[5] = Txt5.Text;
             _parent.ItemNames[6] = Txt6.Text;
             _parent.ItemNames[7] = Txt7.Text;
+
+            _parent.Radius = SldRadius.Value;
 
             Close();
         }

--- a/SettingsWindow.xaml.cs
+++ b/SettingsWindow.xaml.cs
@@ -46,14 +46,14 @@ namespace PieOverlay
             _parent.ItemNames[6] = Txt6.Text;
             _parent.ItemNames[7] = Txt7.Text;
 
-            _parent.ItemHotkeys[0] = Hot0.Text;
-            _parent.ItemHotkeys[1] = Hot1.Text;
-            _parent.ItemHotkeys[2] = Hot2.Text;
-            _parent.ItemHotkeys[3] = Hot3.Text;
-            _parent.ItemHotkeys[4] = Hot4.Text;
-            _parent.ItemHotkeys[5] = Hot5.Text;
-            _parent.ItemHotkeys[6] = Hot6.Text;
-            _parent.ItemHotkeys[7] = Hot7.Text;
+            _parent.ItemHotkeys[0] = Hot0.Text.Trim();
+            _parent.ItemHotkeys[1] = Hot1.Text.Trim();
+            _parent.ItemHotkeys[2] = Hot2.Text.Trim();
+            _parent.ItemHotkeys[3] = Hot3.Text.Trim();
+            _parent.ItemHotkeys[4] = Hot4.Text.Trim();
+            _parent.ItemHotkeys[5] = Hot5.Text.Trim();
+            _parent.ItemHotkeys[6] = Hot6.Text.Trim();
+            _parent.ItemHotkeys[7] = Hot7.Text.Trim();
 
             _parent.Radius = SldRadius.Value;
 

--- a/SettingsWindow.xaml.cs
+++ b/SettingsWindow.xaml.cs
@@ -30,8 +30,9 @@ namespace PieOverlay
             Hot6.Text = _parent.ItemHotkeys[6];
             Hot7.Text = _parent.ItemHotkeys[7];
 
-            // load radius
+            // load radius and behavior
             SldRadius.Value = _parent.Radius;
+            CmbMode.SelectedIndex = (int)_parent.Behavior;
         }
 
         private void OnSave(object sender, RoutedEventArgs e)
@@ -56,6 +57,7 @@ namespace PieOverlay
             _parent.ItemHotkeys[7] = Hot7.Text.Trim();
 
             _parent.Radius = SldRadius.Value;
+            _parent.Behavior = (SelectionMode)CmbMode.SelectedIndex;
 
             Close();
         }


### PR DESCRIPTION
## Summary
- make pie menu radius configurable via a settings slider
- expose radius property in main window and use it when drawing the menu

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_688faff641d8832db739e69df478d4a3