### PR TITLE
Add adjustable dead zone for pie menu hover selection

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -8,7 +8,6 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Effects;
 using System.Windows.Threading;
-using MediaColor = System.Windows.Media.Color;
 
 namespace PieOverlay
 {
@@ -31,7 +30,7 @@ namespace PieOverlay
         public double DeadzoneRadius { get; set; } = 20;
 
         // Appearance of item labels
-        public MediaColor ItemForeground { get; set; } = Colors.DarkBlue;
+        public System.Windows.Media.Color ItemForeground { get; set; } = System.Windows.Media.Colors.DarkBlue;
         public double ItemFontSize { get; set; } = 14;
         public string ItemFontFamily { get; set; } = "Segoe UI";
 
@@ -263,7 +262,7 @@ namespace PieOverlay
                 BlurRadius  = 8,
                 ShadowDepth = 2,
                 Opacity     = 0.4,
-                Color       = Colors.Black
+                Color       = System.Windows.Media.Colors.Black
             };
 
             for (int i = 0; i < count; i++)

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -29,6 +29,11 @@ namespace PieOverlay
         // Dead zone radius around center where no item is selected
         public double DeadzoneRadius { get; set; } = 20;
 
+        // Appearance of item labels
+        public Color ItemForeground { get; set; } = Colors.DarkBlue;
+        public double ItemFontSize { get; set; } = 14;
+        public string ItemFontFamily { get; set; } = "Segoe UI";
+
         // Selection behavior: hover (default) or click
         public SelectionMode Behavior { get; set; } = SelectionMode.Hover;
 
@@ -276,10 +281,11 @@ namespace PieOverlay
 
                 var label = new TextBlock {
                     Text                = ItemNames[i],
-                    FontSize            = 14,
+                    FontSize            = ItemFontSize,
+                    FontFamily          = new FontFamily(ItemFontFamily),
                     HorizontalAlignment = HorizontalAlignment.Center,
                     VerticalAlignment   = VerticalAlignment.Center,
-                    Foreground          = Brushes.DarkBlue
+                    Foreground          = new SolidColorBrush(ItemForeground)
                 };
 
                 border.Child = label;

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -26,6 +26,9 @@ namespace PieOverlay
         // Radius of the pie menu; default 100 but configurable in settings
         public double Radius { get; set; } = 100;
 
+        // Dead zone radius around center where no item is selected
+        public double DeadzoneRadius { get; set; } = 20;
+
         // Selection behavior: hover (default) or click
         public SelectionMode Behavior { get; set; } = SelectionMode.Hover;
 
@@ -132,7 +135,8 @@ namespace PieOverlay
                         double dy = cp.Y - wnd._centerY;
 
                         int idx = -1;
-                        if (dx != 0 || dy != 0)
+                        double distance = Math.Sqrt(dx * dx + dy * dy);
+                        if (distance >= wnd.DeadzoneRadius)
                         {
                             double angle = Math.Atan2(dy, dx);
                             double degrees = angle * 180 / Math.PI;

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -8,6 +8,7 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Effects;
 using System.Windows.Threading;
+using MediaColor = System.Windows.Media.Color;
 
 namespace PieOverlay
 {
@@ -30,7 +31,7 @@ namespace PieOverlay
         public double DeadzoneRadius { get; set; } = 20;
 
         // Appearance of item labels
-        public Color ItemForeground { get; set; } = Colors.DarkBlue;
+        public MediaColor ItemForeground { get; set; } = Colors.DarkBlue;
         public double ItemFontSize { get; set; } = 14;
         public string ItemFontFamily { get; set; } = "Segoe UI";
 

--- a/PieOverlay.csproj
+++ b/PieOverlay.csproj
@@ -3,6 +3,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net8.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/SettingsWindow.xaml
+++ b/SettingsWindow.xaml
@@ -3,11 +3,14 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     Title="Pie Menu Settings"
-    Height="350" Width="400"
+    Height="450" Width="400"
     WindowStartupLocation="CenterOwner"
     ResizeMode="NoResize">
   <Grid Margin="10">
     <Grid.RowDefinitions>
+      <RowDefinition Height="Auto"/>
+      <RowDefinition Height="Auto"/>
+      <RowDefinition Height="Auto"/>
       <RowDefinition Height="Auto"/>
       <RowDefinition Height="Auto"/>
       <RowDefinition Height="Auto"/>
@@ -72,8 +75,17 @@
     <Label Content="Dead zone:" Grid.Row="10" Grid.Column="0" VerticalAlignment="Center"/>
     <Slider x:Name="SldDeadzone" Grid.Row="10" Grid.Column="1" Grid.ColumnSpan="2" Margin="4" Minimum="0" Maximum="100" TickFrequency="5" IsSnapToTickEnabled="True"/>
 
+    <Label Content="Color:" Grid.Row="11" Grid.Column="0" VerticalAlignment="Center"/>
+    <TextBox x:Name="TxtColor" Grid.Row="11" Grid.Column="1" Grid.ColumnSpan="2" Margin="4"/>
+
+    <Label Content="Font size:" Grid.Row="12" Grid.Column="0" VerticalAlignment="Center"/>
+    <Slider x:Name="SldFontSize" Grid.Row="12" Grid.Column="1" Grid.ColumnSpan="2" Margin="4" Minimum="8" Maximum="36" TickFrequency="1" IsSnapToTickEnabled="True"/>
+
+    <Label Content="Font family:" Grid.Row="13" Grid.Column="0" VerticalAlignment="Center"/>
+    <TextBox x:Name="TxtFontFamily" Grid.Row="13" Grid.Column="1" Grid.ColumnSpan="2" Margin="4"/>
+
     <!-- buttons -->
-    <StackPanel Grid.Row="11" Grid.ColumnSpan="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+    <StackPanel Grid.Row="14" Grid.ColumnSpan="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
       <Button Content="Save"   Width="75" Margin="4" Click="OnSave"/>
       <Button Content="Cancel" Width="75" Margin="4" Click="OnCancel"/>
     </StackPanel>

--- a/SettingsWindow.xaml
+++ b/SettingsWindow.xaml
@@ -19,6 +19,7 @@
       <RowDefinition Height="Auto"/>
       <RowDefinition Height="Auto"/>
       <RowDefinition Height="Auto"/>
+      <RowDefinition Height="Auto"/>
     </Grid.RowDefinitions>
     <Grid.ColumnDefinitions>
       <ColumnDefinition Width="Auto"/>
@@ -68,8 +69,11 @@
     <Label Content="Radius:" Grid.Row="9" Grid.Column="0" VerticalAlignment="Center"/>
     <Slider x:Name="SldRadius" Grid.Row="9" Grid.Column="1" Grid.ColumnSpan="2" Margin="4" Minimum="50" Maximum="200" TickFrequency="10" IsSnapToTickEnabled="True"/>
 
+    <Label Content="Dead zone:" Grid.Row="10" Grid.Column="0" VerticalAlignment="Center"/>
+    <Slider x:Name="SldDeadzone" Grid.Row="10" Grid.Column="1" Grid.ColumnSpan="2" Margin="4" Minimum="0" Maximum="100" TickFrequency="5" IsSnapToTickEnabled="True"/>
+
     <!-- buttons -->
-    <StackPanel Grid.Row="10" Grid.ColumnSpan="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+    <StackPanel Grid.Row="11" Grid.ColumnSpan="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
       <Button Content="Save"   Width="75" Margin="4" Click="OnSave"/>
       <Button Content="Cancel" Width="75" Margin="4" Click="OnCancel"/>
     </StackPanel>

--- a/SettingsWindow.xaml
+++ b/SettingsWindow.xaml
@@ -76,13 +76,13 @@
     <Slider x:Name="SldDeadzone" Grid.Row="10" Grid.Column="1" Grid.ColumnSpan="2" Margin="4" Minimum="0" Maximum="100" TickFrequency="5" IsSnapToTickEnabled="True"/>
 
     <Label Content="Color:" Grid.Row="11" Grid.Column="0" VerticalAlignment="Center"/>
-    <TextBox x:Name="TxtColor" Grid.Row="11" Grid.Column="1" Grid.ColumnSpan="2" Margin="4"/>
+    <Button x:Name="BtnColor" Grid.Row="11" Grid.Column="1" Grid.ColumnSpan="2" Margin="4" Height="25" Click="OnChooseColor"/>
 
     <Label Content="Font size:" Grid.Row="12" Grid.Column="0" VerticalAlignment="Center"/>
     <Slider x:Name="SldFontSize" Grid.Row="12" Grid.Column="1" Grid.ColumnSpan="2" Margin="4" Minimum="8" Maximum="36" TickFrequency="1" IsSnapToTickEnabled="True"/>
 
     <Label Content="Font family:" Grid.Row="13" Grid.Column="0" VerticalAlignment="Center"/>
-    <TextBox x:Name="TxtFontFamily" Grid.Row="13" Grid.Column="1" Grid.ColumnSpan="2" Margin="4"/>
+    <ComboBox x:Name="CmbFontFamily" Grid.Row="13" Grid.Column="1" Grid.ColumnSpan="2" Margin="4"/>
 
     <!-- buttons -->
     <StackPanel Grid.Row="14" Grid.ColumnSpan="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">

--- a/SettingsWindow.xaml.cs
+++ b/SettingsWindow.xaml.cs
@@ -3,13 +3,14 @@ using System.Windows;
 using System.Windows.Media;
 using DrawingColor = System.Drawing.Color;
 using Forms = System.Windows.Forms;
+using MediaColor = System.Windows.Media.Color;
 
 namespace PieOverlay
 {
     public partial class SettingsWindow : Window
     {
         private readonly MainWindow _parent;
-        private Color _selectedColor;
+        private MediaColor _selectedColor;
 
         public SettingsWindow(MainWindow parent)
         {
@@ -88,7 +89,7 @@ namespace PieOverlay
             dlg.Color = DrawingColor.FromArgb(_selectedColor.A, _selectedColor.R, _selectedColor.G, _selectedColor.B);
             if (dlg.ShowDialog() == Forms.DialogResult.OK)
             {
-                _selectedColor = Color.FromArgb(dlg.Color.A, dlg.Color.R, dlg.Color.G, dlg.Color.B);
+                _selectedColor = MediaColor.FromArgb(dlg.Color.A, dlg.Color.R, dlg.Color.G, dlg.Color.B);
                 BtnColor.Background = new SolidColorBrush(_selectedColor);
             }
         }

--- a/SettingsWindow.xaml.cs
+++ b/SettingsWindow.xaml.cs
@@ -1,11 +1,15 @@
+using System.Linq;
 using System.Windows;
 using System.Windows.Media;
+using DrawingColor = System.Drawing.Color;
+using Forms = System.Windows.Forms;
 
 namespace PieOverlay
 {
     public partial class SettingsWindow : Window
     {
         private readonly MainWindow _parent;
+        private Color _selectedColor;
 
         public SettingsWindow(MainWindow parent)
         {
@@ -33,11 +37,16 @@ namespace PieOverlay
 
             // load radius, dead zone and behavior
             SldRadius.Value    = _parent.Radius;
-            SldDeadzone.Value  = _parent.DeadzoneRadius;
+            SldDeadzone.Value   = _parent.DeadzoneRadius;
             CmbMode.SelectedIndex = (int)_parent.Behavior;
-            TxtColor.Text      = _parent.ItemForeground.ToString();
-            SldFontSize.Value  = _parent.ItemFontSize;
-            TxtFontFamily.Text = _parent.ItemFontFamily;
+            _selectedColor       = _parent.ItemForeground;
+            BtnColor.Background  = new SolidColorBrush(_selectedColor);
+            SldFontSize.Value    = _parent.ItemFontSize;
+            CmbFontFamily.ItemsSource = Fonts.SystemFontFamilies
+                .Select(f => f.Source)
+                .OrderBy(s => s)
+                .ToList();
+            CmbFontFamily.SelectedItem = _parent.ItemFontFamily;
         }
 
         private void OnSave(object sender, RoutedEventArgs e)
@@ -64,16 +73,24 @@ namespace PieOverlay
             _parent.Radius        = SldRadius.Value;
             _parent.DeadzoneRadius = SldDeadzone.Value;
             _parent.Behavior      = (SelectionMode)CmbMode.SelectedIndex;
-            try { _parent.ItemForeground = (Color)ColorConverter.ConvertFromString(TxtColor.Text); } catch { }
+            _parent.ItemForeground = _selectedColor;
             _parent.ItemFontSize   = SldFontSize.Value;
-            _parent.ItemFontFamily = TxtFontFamily.Text;
+            _parent.ItemFontFamily = CmbFontFamily.SelectedItem as string ?? _parent.ItemFontFamily;
 
             Close();
         }
 
-        private void OnCancel(object sender, RoutedEventArgs e)
+        private void OnCancel(object sender, RoutedEventArgs e) => Close();
+
+        private void OnChooseColor(object sender, RoutedEventArgs e)
         {
-            Close();
+            using var dlg = new Forms.ColorDialog();
+            dlg.Color = DrawingColor.FromArgb(_selectedColor.A, _selectedColor.R, _selectedColor.G, _selectedColor.B);
+            if (dlg.ShowDialog() == Forms.DialogResult.OK)
+            {
+                _selectedColor = Color.FromArgb(dlg.Color.A, dlg.Color.R, dlg.Color.G, dlg.Color.B);
+                BtnColor.Background = new SolidColorBrush(_selectedColor);
+            }
         }
     }
 }

--- a/SettingsWindow.xaml.cs
+++ b/SettingsWindow.xaml.cs
@@ -1,16 +1,14 @@
 using System.Linq;
 using System.Windows;
 using System.Windows.Media;
-using DrawingColor = System.Drawing.Color;
 using Forms = System.Windows.Forms;
-using MediaColor = System.Windows.Media.Color;
 
 namespace PieOverlay
 {
     public partial class SettingsWindow : Window
     {
         private readonly MainWindow _parent;
-        private MediaColor _selectedColor;
+        private System.Windows.Media.Color _selectedColor;
 
         public SettingsWindow(MainWindow parent)
         {
@@ -86,10 +84,10 @@ namespace PieOverlay
         private void OnChooseColor(object sender, RoutedEventArgs e)
         {
             using var dlg = new Forms.ColorDialog();
-            dlg.Color = DrawingColor.FromArgb(_selectedColor.A, _selectedColor.R, _selectedColor.G, _selectedColor.B);
+            dlg.Color = System.Drawing.Color.FromArgb(_selectedColor.A, _selectedColor.R, _selectedColor.G, _selectedColor.B);
             if (dlg.ShowDialog() == Forms.DialogResult.OK)
             {
-                _selectedColor = MediaColor.FromArgb(dlg.Color.A, dlg.Color.R, dlg.Color.G, dlg.Color.B);
+                _selectedColor = System.Windows.Media.Color.FromArgb(dlg.Color.A, dlg.Color.R, dlg.Color.G, dlg.Color.B);
                 BtnColor.Background = new SolidColorBrush(_selectedColor);
             }
         }

--- a/SettingsWindow.xaml.cs
+++ b/SettingsWindow.xaml.cs
@@ -30,8 +30,9 @@ namespace PieOverlay
             Hot6.Text = _parent.ItemHotkeys[6];
             Hot7.Text = _parent.ItemHotkeys[7];
 
-            // load radius and behavior
-            SldRadius.Value = _parent.Radius;
+            // load radius, dead zone and behavior
+            SldRadius.Value    = _parent.Radius;
+            SldDeadzone.Value  = _parent.DeadzoneRadius;
             CmbMode.SelectedIndex = (int)_parent.Behavior;
         }
 
@@ -56,8 +57,9 @@ namespace PieOverlay
             _parent.ItemHotkeys[6] = Hot6.Text.Trim();
             _parent.ItemHotkeys[7] = Hot7.Text.Trim();
 
-            _parent.Radius = SldRadius.Value;
-            _parent.Behavior = (SelectionMode)CmbMode.SelectedIndex;
+            _parent.Radius        = SldRadius.Value;
+            _parent.DeadzoneRadius = SldDeadzone.Value;
+            _parent.Behavior      = (SelectionMode)CmbMode.SelectedIndex;
 
             Close();
         }

--- a/SettingsWindow.xaml.cs
+++ b/SettingsWindow.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using System.Windows.Media;
 
 namespace PieOverlay
 {
@@ -34,6 +35,9 @@ namespace PieOverlay
             SldRadius.Value    = _parent.Radius;
             SldDeadzone.Value  = _parent.DeadzoneRadius;
             CmbMode.SelectedIndex = (int)_parent.Behavior;
+            TxtColor.Text      = _parent.ItemForeground.ToString();
+            SldFontSize.Value  = _parent.ItemFontSize;
+            TxtFontFamily.Text = _parent.ItemFontFamily;
         }
 
         private void OnSave(object sender, RoutedEventArgs e)
@@ -60,6 +64,9 @@ namespace PieOverlay
             _parent.Radius        = SldRadius.Value;
             _parent.DeadzoneRadius = SldDeadzone.Value;
             _parent.Behavior      = (SelectionMode)CmbMode.SelectedIndex;
+            try { _parent.ItemForeground = (Color)ColorConverter.ConvertFromString(TxtColor.Text); } catch { }
+            _parent.ItemFontSize   = SldFontSize.Value;
+            _parent.ItemFontFamily = TxtFontFamily.Text;
 
             Close();
         }


### PR DESCRIPTION
## Summary
- add `DeadzoneRadius` property so hover selection ignores mouse near center
- expose dead zone radius slider in settings window

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68907ed4679c832da860d7f874054ce9